### PR TITLE
Increase timeout for GitHub Pages deployment to 15 minutes

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -27,7 +27,7 @@ defaults:
 jobs:
   deploy:
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration. The deployment job timeout has been increased from 5 minutes to 15 minutes to allow more time for the job to complete.