### PR TITLE
Increase job timeout in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ defaults:
 jobs:
   lint:
     runs-on: ubuntu-24.04
-    timeout-minutes: 3
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Use Node.js
@@ -53,7 +53,7 @@ jobs:
   test:
     needs: [lint]
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Use Node.js
@@ -87,7 +87,7 @@ jobs:
   coverage:
     needs: [test]
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       pull-requests: write
       contents: read


### PR DESCRIPTION
Increased timeout for lint, test, and coverage jobs to allow more time for execution.