### PR TITLE
chore: update linting process to include TypeScript checks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: install dependencies
         run: npm ci
       - name: lint
-        run: npm run lint
+        run: npm run lint && npm run lint:ts
       - name: fmt
         run: npm run fmt:check
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "watch": "vite build --watch --mode development",
     "lint": "oxlint docs scripts src tests *.ts",
     "lint:fix": "npm run lint -- --fix",
+    "lint:ts": "npx tsc --noEmit --skipLibCheck",
     "fmt": "oxfmt docs scripts src tests *.ts",
     "fmt:check": "npm run fmt -- --check",
     "test": "vitest run --project node",

--- a/src/sentry_event.ts
+++ b/src/sentry_event.ts
@@ -51,7 +51,7 @@ export interface UnexpectedStopEvent {
 export interface ClickExternalLinkEvent {
     type: 'click_external_link'
     tags: {
-        link: 'support' | 'review'
+        link: 'support' | 'review' | 'terms' | 'privacy'
     }
 }
 


### PR DESCRIPTION
This pull request enhances the linting process in the project by adding TypeScript type checking as part of the lint workflow. Now, both code style issues and type errors will be caught during CI runs.

**Linting improvements:**

* Added a new `lint:ts` script to `package.json` that runs TypeScript's compiler (`tsc`) in type-checking mode without emitting output.
* Updated the CI workflow in `.github/workflows/test.yaml` to run both the standard linter and the new TypeScript type-checking step during the lint job.