### PR TITLE
fix(option): implement hash handling for tab activation and navigation

### DIFF
--- a/src/element/tab.ts
+++ b/src/element/tab.ts
@@ -8,10 +8,68 @@ import '@material/web/icon/icon'
 import type { Cropping } from './cropping'
 import { t } from '../i18n'
 
+interface TabDefinition {
+    id: string
+    panelId: string
+    hash: string
+}
+
+const TAB_DEFINITIONS: readonly TabDefinition[] = [
+    { id: 'tab-main', panelId: 'panel-main', hash: '' },
+    { id: 'tab-settings', panelId: 'panel-settings', hash: '#settings' },
+    { id: 'tab-cropping', panelId: 'panel-cropping', hash: '#cropping' },
+    { id: 'tab-support', panelId: 'panel-support', hash: '#support' },
+] as const
+
+function getTabByHash(hash: string): TabDefinition {
+    const cleanHash = hash.startsWith('#') ? hash : hash ? `#${hash}` : ''
+    return (
+        TAB_DEFINITIONS.find(tab => tab.hash !== '' && tab.hash.toLowerCase() === cleanHash.toLowerCase()) ??
+        TAB_DEFINITIONS[0]
+    )
+}
+
+function updateHash(hash: string, replace?: boolean) {
+    if (replace) {
+        history.replaceState(null, '', window.location.pathname + window.location.search)
+        return
+    }
+    if (hash) {
+        if (window.location.hash !== hash) {
+            history.pushState(null, '', hash)
+        }
+        return
+    }
+    if (window.location.hash) {
+        history.pushState(null, '', window.location.pathname + window.location.search)
+    }
+}
+
 @customElement('option-tab')
 export class OptionTab extends LitElement {
     public constructor() {
         super()
+    }
+
+    public override connectedCallback() {
+        super.connectedCallback()
+        window.addEventListener('hashchange', this.handleHashChange)
+    }
+
+    public override disconnectedCallback() {
+        super.disconnectedCallback()
+        window.removeEventListener('hashchange', this.handleHashChange)
+    }
+
+    public override firstUpdated() {
+        const currentHash = window.location.hash
+        const activeTab = getTabByHash(currentHash)
+        if (currentHash && activeTab.hash === '') {
+            updateHash('', true)
+        }
+        if (activeTab.id === 'tab-cropping') {
+            OptionTab.notifyCroppingTabState(true)
+        }
     }
 
     private static getPanel(tabs: MdTabs, tab: Tab): HTMLElement | null {
@@ -20,22 +78,21 @@ export class OptionTab extends LitElement {
         return root.querySelector<HTMLElement>(`#${panelId}`)
     }
 
-    private static notifyCroppingTabState(isActive: boolean) {
+    private static async notifyCroppingTabState(isActive: boolean) {
+        await customElements.whenDefined('extension-cropping')
         const croppingElement = document.querySelector<Cropping>('extension-cropping')
-        if (croppingElement) {
+        if (croppingElement && typeof croppingElement.setTabActive === 'function') {
             croppingElement.setTabActive(isActive)
         }
     }
 
-    private static changeTab(e: Event) {
-        if (!(e.target instanceof MdTabs)) return
-        const tabs = e.target
-
-        e.target.tabs.forEach(tab => {
-            if (tab.active) return
+    private syncTabPanels(tabs: MdTabs, activeTab: Tab | null) {
+        tabs.tabs.forEach(tab => {
+            if (tab === activeTab) return
             const panel = OptionTab.getPanel(tabs, tab)
-            if (panel == null || panel.hidden) return
-            panel.hidden = true
+            if (panel && !panel.hidden) {
+                panel.hidden = true
+            }
 
             // Notify cropping tab when it becomes inactive
             if (tab.id === 'tab-cropping') {
@@ -43,47 +100,109 @@ export class OptionTab extends LitElement {
             }
         })
 
-        if (e.target.activeTab == null) return
-        const currentPanel = OptionTab.getPanel(tabs, e.target.activeTab)
-        if (currentPanel == null) return
-        currentPanel.hidden = false
+        if (!activeTab) return
+        const currentPanel = OptionTab.getPanel(tabs, activeTab)
+        if (currentPanel) {
+            currentPanel.hidden = false
+        }
 
         // Notify cropping tab when it becomes active
-        if (e.target.activeTab.id === 'tab-cropping') {
+        if (activeTab.id === 'tab-cropping') {
             OptionTab.notifyCroppingTabState(true)
         }
     }
 
+    private changeTab = (e: Event) => {
+        if (!(e.target instanceof MdTabs)) return
+        const tabs = e.target
+
+        this.syncTabPanels(tabs, tabs.activeTab)
+
+        const activeTabId = tabs.activeTab?.id
+        const tabDef = TAB_DEFINITIONS.find(item => item.id === activeTabId)
+        if (tabDef) {
+            updateHash(tabDef.hash)
+        }
+    }
+
+    private handleHashChange = () => {
+        const activeTabDef = getTabByHash(window.location.hash)
+        if (window.location.hash && activeTabDef.hash === '') {
+            updateHash('', true)
+        }
+        const tabs = this.shadowRoot?.querySelector<MdTabs>('md-tabs')
+        if (!tabs) return
+
+        const targetTab = tabs.tabs.find(tab => tab.id === activeTabDef.id)
+        if (!targetTab) return
+
+        if (tabs.activeTab !== targetTab) {
+            tabs.activeTab = targetTab
+        } else {
+            this.syncTabPanels(tabs, targetTab)
+        }
+    }
+
     public override render() {
+        const activeTab = getTabByHash(window.location.hash)
+
         return html`
-            <md-tabs @change=${OptionTab.changeTab}>
-                <md-primary-tab id="tab-main" aria-controls="panel-main" inline-icon active>
+            <md-tabs @change=${this.changeTab}>
+                <md-primary-tab
+                    id="tab-main"
+                    aria-controls="panel-main"
+                    inline-icon
+                    ?active=${activeTab.id === 'tab-main'}>
                     <md-icon slot="icon">video_library</md-icon>
                     ${t('tabRecords')}
                 </md-primary-tab>
-                <md-primary-tab id="tab-settings" aria-controls="panel-settings" inline-icon>
+                <md-primary-tab
+                    id="tab-settings"
+                    aria-controls="panel-settings"
+                    inline-icon
+                    ?active=${activeTab.id === 'tab-settings'}>
                     <md-icon slot="icon">settings</md-icon>
                     ${t('tabSettings')}
                 </md-primary-tab>
-                <md-primary-tab id="tab-cropping" aria-controls="panel-cropping" inline-icon>
+                <md-primary-tab
+                    id="tab-cropping"
+                    aria-controls="panel-cropping"
+                    inline-icon
+                    ?active=${activeTab.id === 'tab-cropping'}>
                     <md-icon slot="icon">crop</md-icon>
                     ${t('tabCropping')}
                 </md-primary-tab>
-                <md-primary-tab id="tab-support" aria-controls="panel-support" inline-icon>
+                <md-primary-tab
+                    id="tab-support"
+                    aria-controls="panel-support"
+                    inline-icon
+                    ?active=${activeTab.id === 'tab-support'}>
                     <md-icon slot="icon">support</md-icon>
                     ${t('tabSupport')}
                 </md-primary-tab>
             </md-tabs>
-            <div role="tabpanel" id="panel-main" aria-labelledby="tab-main">
+            <div role="tabpanel" id="panel-main" aria-labelledby="tab-main" ?hidden=${activeTab.id !== 'tab-main'}>
                 <slot name="panel-main"></slot>
             </div>
-            <div role="tabpanel" id="panel-settings" aria-labelledby="tab-settings" hidden>
+            <div
+                role="tabpanel"
+                id="panel-settings"
+                aria-labelledby="tab-settings"
+                ?hidden=${activeTab.id !== 'tab-settings'}>
                 <slot name="panel-settings"></slot>
             </div>
-            <div role="tabpanel" id="panel-cropping" aria-labelledby="tab-cropping" hidden>
+            <div
+                role="tabpanel"
+                id="panel-cropping"
+                aria-labelledby="tab-cropping"
+                ?hidden=${activeTab.id !== 'tab-cropping'}>
                 <slot name="panel-cropping"></slot>
             </div>
-            <div role="tabpanel" id="panel-support" aria-labelledby="tab-support" hidden>
+            <div
+                role="tabpanel"
+                id="panel-support"
+                aria-labelledby="tab-support"
+                ?hidden=${activeTab.id !== 'tab-support'}>
                 <slot name="panel-support"></slot>
             </div>
         `

--- a/tests/element/tab.test.ts
+++ b/tests/element/tab.test.ts
@@ -1,6 +1,6 @@
 import { render } from 'vitest-browser-lit'
 import { html } from 'lit'
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, afterEach } from 'vitest'
 import { shadowQuery, shadowQueryAll, elementUpdated } from './test-helpers'
 import '../../src/element/tab'
 import type { OptionTab } from '../../src/element/tab'
@@ -8,6 +8,20 @@ import type { OptionTab } from '../../src/element/tab'
 function renderTab() {
     const screen = render(html`<option-tab></option-tab>`)
     return screen.container.querySelector('option-tab') as OptionTab
+}
+
+function waitForHashChange(timeoutMs = 1000): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            window.removeEventListener('hashchange', onHashChange)
+            reject(new Error(`Timeout waiting for hashchange event (${timeoutMs}ms)`))
+        }, timeoutMs)
+        const onHashChange = () => {
+            clearTimeout(timer)
+            resolve()
+        }
+        window.addEventListener('hashchange', onHashChange, { once: true })
+    })
 }
 
 describe('option-tab', () => {
@@ -78,5 +92,339 @@ describe('option-tab', () => {
         expect(slotNames).toContain('panel-settings')
         expect(slotNames).toContain('panel-cropping')
         expect(slotNames).toContain('panel-support')
+    })
+
+    describe('hash handling', () => {
+        afterEach(() => {
+            history.replaceState(null, '', window.location.pathname + window.location.search)
+        })
+
+        test('activates Settings tab when hash is #settings', async () => {
+            history.replaceState(null, '', '#settings')
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const settingsTab = shadowQuery(el, '#tab-settings')
+            const settingsPanel = shadowQuery(el, '#panel-settings')
+            const mainPanel = shadowQuery(el, '#panel-main')
+
+            expect(settingsTab?.hasAttribute('active')).toBe(true)
+            expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
+            expect(mainPanel?.hasAttribute('hidden')).toBe(true)
+        })
+
+        test('activates Cropping tab when hash is #cropping', async () => {
+            history.replaceState(null, '', '#cropping')
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const croppingTab = shadowQuery(el, '#tab-cropping')
+            const croppingPanel = shadowQuery(el, '#panel-cropping')
+            const mainPanel = shadowQuery(el, '#panel-main')
+
+            expect(croppingTab?.hasAttribute('active')).toBe(true)
+            expect(croppingPanel?.hasAttribute('hidden')).toBe(false)
+            expect(mainPanel?.hasAttribute('hidden')).toBe(true)
+        })
+
+        test('activates Support tab when hash is #support', async () => {
+            history.replaceState(null, '', '#support')
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const supportTab = shadowQuery(el, '#tab-support')
+            const supportPanel = shadowQuery(el, '#panel-support')
+            const mainPanel = shadowQuery(el, '#panel-main')
+
+            expect(supportTab?.hasAttribute('active')).toBe(true)
+            expect(supportPanel?.hasAttribute('hidden')).toBe(false)
+            expect(mainPanel?.hasAttribute('hidden')).toBe(true)
+        })
+
+        test('activates corresponding tab with case-insensitive hash e.g. #SETTINGS', async () => {
+            history.replaceState(null, '', '#SETTINGS')
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const settingsTab = shadowQuery(el, '#tab-settings')
+            const settingsPanel = shadowQuery(el, '#panel-settings')
+            expect(settingsTab?.hasAttribute('active')).toBe(true)
+            expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
+        })
+
+        test('defaults to first tab and clears hash when hash is only #', async () => {
+            history.replaceState(null, '', window.location.pathname + window.location.search + '#')
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const mainTab = shadowQuery(el, '#tab-main')
+            const mainPanel = shadowQuery(el, '#panel-main')
+            expect(mainTab?.hasAttribute('active')).toBe(true)
+            expect(mainPanel?.hasAttribute('hidden')).toBe(false)
+            expect(window.location.hash).toBe('')
+        })
+
+        test('displays first tab and has no back history when opened with undefined hash in a new tab', async () => {
+            // In a fresh tab session, there is no back history yet
+            if ((window as any).navigation) {
+                expect((window as any).navigation.canGoBack).toBe(false)
+            }
+
+            // Set undefined hash on current page (simulating opening option page with undefined hash in a fresh tab)
+            history.replaceState(null, '', '#unknown')
+            expect(window.location.hash).toBe('#unknown')
+
+            const pushStateSpy = vi.spyOn(history, 'pushState')
+            const replaceStateSpy = vi.spyOn(history, 'replaceState')
+            const lengthBefore = history.length
+
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const mainTab = shadowQuery(el, '#tab-main')
+            const mainPanel = shadowQuery(el, '#panel-main')
+
+            // 1st tab should be displayed
+            expect(mainTab?.hasAttribute('active')).toBe(true)
+            expect(mainPanel?.hasAttribute('hidden')).toBe(false)
+
+            // The undefined hash should be cleared
+            expect(window.location.hash).toBe('')
+
+            // Verify no history entry was added and replaceState was used
+            expect(pushStateSpy).not.toHaveBeenCalled()
+            expect(replaceStateSpy).toHaveBeenCalledWith(null, '', window.location.pathname + window.location.search)
+            expect(history.length).toBe(lengthBefore)
+
+            // There should be no back history in this tab
+            if ((window as any).navigation) {
+                expect((window as any).navigation.canGoBack).toBe(false)
+            }
+
+            pushStateSpy.mockRestore()
+            replaceStateSpy.mockRestore()
+        })
+
+        test('updates hash when switching tabs and removes hash for first tab', async () => {
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const tabs = shadowQuery(el, 'md-tabs') as any
+            const settingsTab = shadowQuery(el, '#tab-settings') as HTMLElement
+            const croppingTab = shadowQuery(el, '#tab-cropping') as HTMLElement
+            const supportTab = shadowQuery(el, '#tab-support') as HTMLElement
+            const mainTab = shadowQuery(el, '#tab-main') as HTMLElement
+
+            // Switch to Settings
+            tabs.activeTab = settingsTab
+            expect(window.location.hash).toBe('#settings')
+
+            // Switch to Cropping
+            tabs.activeTab = croppingTab
+            expect(window.location.hash).toBe('#cropping')
+
+            // Switch to Support
+            tabs.activeTab = supportTab
+            expect(window.location.hash).toBe('#support')
+
+            // Switch back to Records (first tab)
+            tabs.activeTab = mainTab
+            expect(window.location.hash).toBe('')
+        })
+
+        test('switches tab on hashchange event', async () => {
+            const el = renderTab()
+            await elementUpdated(el)
+
+            // Change hash to #settings
+            const hashChangeToSettings = waitForHashChange()
+            window.location.hash = '#settings'
+            await hashChangeToSettings
+            await elementUpdated(el)
+
+            const settingsTab = shadowQuery(el, '#tab-settings')
+            const settingsPanel = shadowQuery(el, '#panel-settings')
+            expect(settingsTab?.hasAttribute('active')).toBe(true)
+            expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
+
+            // Dispatch hashchange back to empty (first tab)
+            history.replaceState(null, '', window.location.pathname + window.location.search)
+            window.dispatchEvent(new HashChangeEvent('hashchange'))
+            await elementUpdated(el)
+
+            const mainTab = shadowQuery(el, '#tab-main')
+            const mainPanel = shadowQuery(el, '#panel-main')
+            expect(mainTab?.hasAttribute('active')).toBe(true)
+            expect(mainPanel?.hasAttribute('hidden')).toBe(false)
+        })
+
+        test('navigates backward and forward in history', async () => {
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const tabs = shadowQuery(el, 'md-tabs') as any
+            const settingsTab = shadowQuery(el, '#tab-settings') as HTMLElement
+            const croppingTab = shadowQuery(el, '#tab-cropping') as HTMLElement
+            const supportTab = shadowQuery(el, '#tab-support') as HTMLElement
+
+            // Switch tabs: records -> settings -> cropping -> support
+            tabs.activeTab = settingsTab
+            expect(window.location.hash).toBe('#settings')
+
+            tabs.activeTab = croppingTab
+            expect(window.location.hash).toBe('#cropping')
+
+            tabs.activeTab = supportTab
+            expect(window.location.hash).toBe('#support')
+
+            // History back -> #cropping
+            let hashChange = waitForHashChange()
+            history.back()
+            await hashChange
+            await elementUpdated(el)
+
+            expect(window.location.hash).toBe('#cropping')
+            const croppingPanel = shadowQuery(el, '#panel-cropping')
+            expect(croppingTab.hasAttribute('active')).toBe(true)
+            expect(croppingPanel?.hasAttribute('hidden')).toBe(false)
+
+            // History back -> #settings
+            hashChange = waitForHashChange()
+            history.back()
+            await hashChange
+            await elementUpdated(el)
+
+            expect(window.location.hash).toBe('#settings')
+            const settingsPanel = shadowQuery(el, '#panel-settings')
+            expect(settingsTab.hasAttribute('active')).toBe(true)
+            expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
+
+            // History back -> empty (records)
+            hashChange = waitForHashChange()
+            history.back()
+            await hashChange
+            await elementUpdated(el)
+
+            expect(window.location.hash).toBe('')
+            const mainTab = shadowQuery(el, '#tab-main')
+            const mainPanel = shadowQuery(el, '#panel-main')
+            expect(mainTab?.hasAttribute('active')).toBe(true)
+            expect(mainPanel?.hasAttribute('hidden')).toBe(false)
+
+            // History forward -> #settings
+            hashChange = waitForHashChange()
+            history.forward()
+            await hashChange
+            await elementUpdated(el)
+
+            expect(window.location.hash).toBe('#settings')
+            expect(settingsTab.hasAttribute('active')).toBe(true)
+            expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
+
+            // History forward -> #cropping
+            hashChange = waitForHashChange()
+            history.forward()
+            await hashChange
+            await elementUpdated(el)
+
+            expect(window.location.hash).toBe('#cropping')
+            expect(croppingTab.hasAttribute('active')).toBe(true)
+            expect(croppingPanel?.hasAttribute('hidden')).toBe(false)
+        })
+
+        test('pushes history and allows back navigation when switching back to the first tab (records)', async () => {
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const tabs = shadowQuery(el, 'md-tabs') as any
+            const settingsTab = shadowQuery(el, '#tab-settings') as HTMLElement
+            const mainTab = shadowQuery(el, '#tab-main') as HTMLElement
+
+            tabs.activeTab = settingsTab
+            expect(window.location.hash).toBe('#settings')
+
+            // Switch to 1st tab (removes hash via pushState)
+            tabs.activeTab = mainTab
+            expect(window.location.hash).toBe('')
+            const mainPanel = shadowQuery(el, '#panel-main')
+            expect(mainTab.hasAttribute('active')).toBe(true)
+            expect(mainPanel?.hasAttribute('hidden')).toBe(false)
+
+            // History back -> #settings
+            const backHashChange = waitForHashChange()
+            history.back()
+            await backHashChange
+            await elementUpdated(el)
+
+            expect(window.location.hash).toBe('#settings')
+            const settingsPanel = shadowQuery(el, '#panel-settings')
+            expect(settingsTab.hasAttribute('active')).toBe(true)
+            expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
+
+            // History forward -> empty (records)
+            const forwardHashChange = waitForHashChange()
+            history.forward()
+            await forwardHashChange
+            await elementUpdated(el)
+
+            expect(window.location.hash).toBe('')
+            expect(mainTab.hasAttribute('active')).toBe(true)
+            expect(mainPanel?.hasAttribute('hidden')).toBe(false)
+        })
+
+        test('displays first tab and does not leave undefined hash in history when changing hash on already opened page', async () => {
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const tabs = shadowQuery(el, 'md-tabs') as any
+            const settingsTab = shadowQuery(el, '#tab-settings') as HTMLElement
+
+            // Set up an established history entry: switch to #settings
+            tabs.activeTab = settingsTab
+            expect(window.location.hash).toBe('#settings')
+
+            // User/browser changes hash to an undefined hash on the opened page
+            const hashChange = waitForHashChange()
+            window.location.hash = '#undefined-tab'
+            await hashChange
+            await elementUpdated(el)
+
+            // 1st tab should be displayed, and the undefined hash should be replaced (cleared)
+            const mainTab = shadowQuery(el, '#tab-main')
+            const mainPanel = shadowQuery(el, '#panel-main')
+            expect(mainTab?.hasAttribute('active')).toBe(true)
+            expect(mainPanel?.hasAttribute('hidden')).toBe(false)
+            expect(window.location.hash).toBe('')
+
+            // Undefined hash must not remain in history:
+            // Going back should directly return to #settings, NOT #undefined-tab
+            const backHashChange = waitForHashChange()
+            history.back()
+            await backHashChange
+            await elementUpdated(el)
+
+            expect(window.location.hash).toBe('#settings')
+            expect(settingsTab.hasAttribute('active')).toBe(true)
+        })
+
+        test('does not duplicate history entries when selecting the already active tab', async () => {
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const tabs = shadowQuery(el, 'md-tabs') as any
+            const settingsTab = shadowQuery(el, '#tab-settings') as HTMLElement
+
+            tabs.activeTab = settingsTab
+            expect(window.location.hash).toBe('#settings')
+
+            const lengthBefore = history.length
+
+            // Trigger change on the same tab
+            tabs.dispatchEvent(new Event('change'))
+            await elementUpdated(el)
+
+            expect(window.location.hash).toBe('#settings')
+            expect(history.length).toBe(lengthBefore)
+        })
     })
 })


### PR DESCRIPTION
This pull request adds robust support for synchronizing the active tab in the `option-tab` component with the browser's URL hash, ensuring that tab state is reflected in and controlled by the URL. It also introduces comprehensive tests to verify this behavior. The main changes include refactoring tab state management, updating the UI to reflect the hash, and adding tests to cover all major hash/tab scenarios.

**Tab state and URL synchronization improvements:**

* Refactored `option-tab` (`src/element/tab.ts`) to use a centralized `TabDefinition` mapping and utility functions for mapping between hash and tab, updating the URL hash when tabs change, and activating the correct tab and panel based on the current hash. The component now listens for `hashchange` events and updates the active tab accordingly.
* Updated the rendering logic so that the correct tab and panel are shown/hidden based on the hash, and the hash is updated or cleared when switching tabs, ensuring deep linking and back/forward navigation work as expected.

**Cropping tab notification improvements:**

* Improved the logic for notifying the `extension-cropping` element about its active state by awaiting its definition and checking for the presence of the `setTabActive` method before calling it.

**Testing enhancements:**

* Added a new test suite in `tests/element/tab.test.ts` to thoroughly test hash-based tab activation, hash updates when switching tabs, default behavior for unknown hashes, and tab switching via hashchange events.