### PR TITLE
fix(transcription): update decoder model file

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -907,6 +907,18 @@
         "message": "Transcription is not available because your browser or GPU does not support WebGPU shader-f16.",
         "description": "Notice displayed when WebGPU shader-f16 is not supported"
     },
+    "settingsTranscriptionModelMissingWarning": {
+        "message": "Model data is missing or corrupted. Please toggle transcription off and on again to redownload the model.",
+        "description": "Warning shown when transcription is enabled but model cache files are missing or incomplete"
+    },
+    "playerModelRedownloadRequired": {
+        "message": "Transcription model is missing or corrupted. Please redownload the model from Settings.",
+        "description": "Error message shown when transcription model files are missing or corrupted"
+    },
+    "playerOpenSettings": {
+        "message": "Open Settings",
+        "description": "Button to navigate to Settings page"
+    },
     "playerTranscriptionLoadingModel": {
         "message": "Loading model",
         "description": "Progress stage: loading model"

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -899,6 +899,14 @@
     "settingsTranscriptionDownloadPending": {
         "message": "Preparing download..."
     },
+    "settingsTranscriptionUnsupportedWebGPU": {
+        "message": "Transcription is not available because your browser does not support WebGPU.",
+        "description": "Notice displayed when WebGPU is not supported by the browser"
+    },
+    "settingsTranscriptionUnsupportedShaderF16": {
+        "message": "Transcription is not available because your browser or GPU does not support WebGPU shader-f16.",
+        "description": "Notice displayed when WebGPU shader-f16 is not supported"
+    },
     "playerTranscriptionLoadingModel": {
         "message": "Loading model",
         "description": "Progress stage: loading model"

--- a/extension/_locales/ja/messages.json
+++ b/extension/_locales/ja/messages.json
@@ -689,6 +689,12 @@
     "settingsTranscriptionDownloadPending": {
         "message": "ダウンロードを準備中..."
     },
+    "settingsTranscriptionUnsupportedWebGPU": {
+        "message": "お使いのブラウザは WebGPU に対応していないため、文字起こし機能を利用できません。"
+    },
+    "settingsTranscriptionUnsupportedShaderF16": {
+        "message": "お使いのブラウザまたは GPU は WebGPU の shader-f16 に対応していないため、文字起こし機能を利用できません。"
+    },
     "playerTranscriptionLoadingModel": {
         "message": "モデル読み込み中"
     },

--- a/extension/_locales/ja/messages.json
+++ b/extension/_locales/ja/messages.json
@@ -695,6 +695,15 @@
     "settingsTranscriptionUnsupportedShaderF16": {
         "message": "お使いのブラウザまたは GPU は WebGPU の shader-f16 に対応していないため、文字起こし機能を利用できません。"
     },
+    "settingsTranscriptionModelMissingWarning": {
+        "message": "モデルデータが見つからないか破損しています。文字起こしを一度オフにしてから再度オンにして、モデルを再ダウンロードしてください。"
+    },
+    "playerModelRedownloadRequired": {
+        "message": "文字起こしモデルが見つからないか破損しています。設定画面からモデルを再ダウンロードしてください。"
+    },
+    "playerOpenSettings": {
+        "message": "設定を開く"
+    },
     "playerTranscriptionLoadingModel": {
         "message": "モデル読み込み中"
     },

--- a/src/element/player.ts
+++ b/src/element/player.ts
@@ -17,6 +17,7 @@ import type { Message } from '../message'
 import { t } from '../i18n'
 import { applyTheme } from '../theme'
 import { recordingApi } from '../api_client'
+import { OPFSModelCache } from '../transcription/opfs_model_cache'
 
 @customElement('extension-player')
 export class Player extends LitElement {
@@ -198,6 +199,10 @@ export class Player extends LitElement {
             margin: 0;
         }
 
+        .error-banner .open-settings-button {
+            margin-top: 8px;
+        }
+
         md-dialog {
             width: 480px;
             --md-dialog-container-color: var(--theme-dialog-bg, var(--md-sys-color-surface-container-high, #1e1e2a));
@@ -238,11 +243,13 @@ export class Player extends LitElement {
     @state() private isTranscribing = false
     @state() private transcribeProgress: { loaded: number; total: number; stage?: string } | null = null
     @state() private transcribeError: string | null = null
+    @state() private needsModelRedownload = false
     @state() private showDownloadMenu = false
     @state() private showDeleteDialog = false
     @state() private trackVersion = 0
     @state() private isControlled = typeof navigator !== 'undefined' && navigator.serviceWorker?.controller != null
 
+    private readonly modelCache = new OPFSModelCache()
     private messageListener?: (message: Message) => void
 
     constructor() {
@@ -382,11 +389,28 @@ export class Player extends LitElement {
         }
     }
 
-    private startTranscription() {
+    private async startTranscription() {
         if (!this.path) return
         this.isTranscribing = true
         this.transcribeError = null
         this.transcribeProgress = null
+        this.needsModelRedownload = false
+
+        try {
+            const hasCache = await this.modelCache.hasCache()
+            if (!hasCache) {
+                this.isTranscribing = false
+                this.needsModelRedownload = true
+                this.transcribeError = t('playerModelRedownloadRequired')
+                return
+            }
+        } catch (e) {
+            console.error('Failed to check model cache:', e)
+            this.isTranscribing = false
+            this.needsModelRedownload = true
+            this.transcribeError = t('playerModelRedownloadRequired')
+            return
+        }
 
         chrome.runtime
             .sendMessage({
@@ -398,6 +422,11 @@ export class Player extends LitElement {
                 this.isTranscribing = false
                 this.transcribeError = e instanceof Error ? e.message : String(e)
             })
+    }
+
+    private openSettingsForTranscription() {
+        const url = chrome.runtime.getURL('option.html?tab=settings#transcription')
+        window.open(url, '_blank')
     }
 
     private handleTimeUpdate(e: Event) {
@@ -534,6 +563,18 @@ export class Player extends LitElement {
                                               ? html`
                                                     <div class="error-banner">
                                                         <p>${this.transcribeError}</p>
+                                                        ${
+                                                            this.needsModelRedownload
+                                                                ? html`
+                                                                      <md-filled-tonal-button
+                                                                          class="open-settings-button"
+                                                                          @click=${this.openSettingsForTranscription}>
+                                                                          <md-icon slot="icon">settings</md-icon>
+                                                                          ${t('playerOpenSettings')}
+                                                                      </md-filled-tonal-button>
+                                                                  `
+                                                                : ''
+                                                        }
                                                     </div>
                                                 `
                                               : ''

--- a/src/element/settings.ts
+++ b/src/element/settings.ts
@@ -245,6 +245,14 @@ export class Settings extends LitElement {
     private isCheckingWebGPU: boolean = false
 
     @property()
+    private isTogglingTranscription: boolean = false
+
+    private transcriptionToggleGeneration: number = 0
+
+    @property()
+    private hasCacheInconsistency: boolean = false
+
+    @property()
     private timerEstimateText: string = ''
 
     private timerEstimateIntervalId: ReturnType<typeof setInterval> | null = null
@@ -267,6 +275,8 @@ export class Settings extends LitElement {
             console.error('Failed to initialize FLAC encoding support.', error)
         }
         await this.validateEncoding()
+        await this.checkCacheConsistency()
+        this.checkAnchorNavigation()
     }
 
     public override render() {
@@ -669,18 +679,22 @@ export class Settings extends LitElement {
                     <label
                         class="switch-label"
                         title="${
-                            !this.isWebGPUSupported
+                            !this.isWebGPUSupported || this.hasCacheInconsistency
                                 ? this.transcriptionHintText
                                 : t('settingsTranscriptionTitle', ModelDownloader.getFormattedTotalSize())
                         }">
                         ${t('settingsTranscription')}
                         <md-switch
-                            id="transcription-switch"
+                            id="transcription"
                             ?selected=${live((this.config.transcription?.enabled ?? false) || this.isModelDownloading)}
-                            ?disabled=${live(!this.isWebGPUSupported || this.isCheckingWebGPU)}
+                            ?disabled=${live(
+                                !this.isWebGPUSupported || this.isCheckingWebGPU || this.isTogglingTranscription,
+                            )}
                             @input=${this.updateTranscriptionEnabled}></md-switch>
                     </label>
-                    <p class="settings-hint ${!this.isWebGPUSupported ? 'error' : ''}">${this.transcriptionHintText}</p>
+                    <p class="settings-hint ${!this.isWebGPUSupported || this.hasCacheInconsistency ? 'error' : ''}">
+                        ${this.transcriptionHintText}
+                    </p>
 
                     ${
                         this.isModelDownloading
@@ -948,6 +962,9 @@ export class Settings extends LitElement {
             }
             return t('settingsTranscriptionUnsupportedWebGPU')
         }
+        if (this.hasCacheInconsistency && this.config.transcription?.enabled) {
+            return t('settingsTranscriptionModelMissingWarning')
+        }
         const modelSize = ModelDownloader.getFormattedTotalSize()
         if (this.isModelDownloading) {
             return t('settingsTranscriptionDownloadingHint')
@@ -1214,6 +1231,7 @@ export class Settings extends LitElement {
                 case 'model-download-complete':
                     this.isModelDownloading = false
                     this.downloadProgress = null
+                    this.hasCacheInconsistency = false
                     this.config.transcription.enabled = true
                     Settings.setConfiguration(this.config)
                     Settings.syncConfiguration(this.config)
@@ -1258,6 +1276,59 @@ export class Settings extends LitElement {
         }
     }
 
+    /**
+     * Checks whether the transcription model cache is complete when transcription is enabled.
+     * Sets hasCacheInconsistency flag and triggers update if inconsistency is detected.
+     */
+    public async checkCacheConsistency(): Promise<boolean> {
+        if (!this.config.transcription?.enabled || this.isModelDownloading) {
+            this.hasCacheInconsistency = false
+            return true
+        }
+
+        const hasCache = await this.modelCache.hasCache()
+        if (!this.config.transcription?.enabled || this.isModelDownloading) {
+            this.hasCacheInconsistency = false
+            this.requestUpdate()
+            return true
+        }
+
+        this.hasCacheInconsistency = !hasCache
+        this.requestUpdate()
+        return hasCache
+    }
+
+    /**
+     * Called when the Settings tab becomes active/inactive.
+     */
+    public async setTabActive(isActive: boolean) {
+        if (isActive) {
+            await this.checkCacheConsistency()
+            this.checkAnchorNavigation()
+        }
+    }
+
+    private checkAnchorNavigation() {
+        const hash = window.location.hash
+        if (!hash) return
+        const targetId = hash.startsWith('#') ? hash.slice(1) : hash
+        if (targetId === 'transcription') {
+            this.scrollToTranscriptionSwitch()
+        }
+    }
+
+    private scrollToTranscriptionSwitch() {
+        requestAnimationFrame(() => {
+            const switchEl = this.shadowRoot?.querySelector('#transcription')
+            if (switchEl) {
+                switchEl.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                if ('focus' in switchEl && typeof switchEl.focus === 'function') {
+                    switchEl.focus()
+                }
+            }
+        })
+    }
+
     /** ユーザーが意図的にトグルOFFでキャンセルしたことを示すフラグ（エラー抑制用） */
     private isUserCancellingDownload = false
 
@@ -1266,67 +1337,87 @@ export class Settings extends LitElement {
         if (!(target instanceof MdSwitch)) return
         const enabled = target.selected
 
-        if (enabled) {
-            this.downloadError = null
-            this.isCheckingWebGPU = true
-            this.requestUpdate()
+        const currentGen = ++this.transcriptionToggleGeneration
+        this.isTogglingTranscription = true
+        this.requestUpdate()
 
-            let gpuSupport
-            try {
-                gpuSupport = await checkWebGPUSupport()
-            } finally {
-                this.isCheckingWebGPU = false
-            }
-
-            if (!gpuSupport.supported) {
-                this.isWebGPUSupported = false
-                this.transcriptionUnsupportedReason = gpuSupport.reason ?? 'no-webgpu'
-                target.selected = false
-                this.config.transcription.enabled = false
+        try {
+            if (enabled) {
+                this.downloadError = null
+                this.isCheckingWebGPU = true
                 this.requestUpdate()
-                return
-            }
 
-            // トグルON: モデルがキャッシュ済みならそのまま有効化、未キャッシュなら即ダウンロード開始
-            const isCached = await this.modelCache.hasCache()
-            if (!isCached) {
-                this.isModelDownloading = true
+                let gpuSupport
+                try {
+                    gpuSupport = await checkWebGPUSupport()
+                } finally {
+                    this.isCheckingWebGPU = false
+                }
+
+                if (this.transcriptionToggleGeneration !== currentGen) return
+
+                if (!gpuSupport.supported) {
+                    this.isWebGPUSupported = false
+                    this.transcriptionUnsupportedReason = gpuSupport.reason ?? 'no-webgpu'
+                    target.selected = false
+                    this.config.transcription.enabled = false
+                    this.requestUpdate()
+                    return
+                }
+
+                // トグルON: モデルがキャッシュ済みならそのまま有効化、未キャッシュなら即ダウンロード開始
+                const isCached = await this.modelCache.hasCache()
+                if (this.transcriptionToggleGeneration !== currentGen) return
+
+                if (!isCached) {
+                    this.isModelDownloading = true
+                    this.downloadProgress = null
+                    this.requestUpdate()
+                    try {
+                        await chrome.runtime.sendMessage({ type: 'start-model-download' })
+                    } catch (err) {
+                        if (this.transcriptionToggleGeneration !== currentGen) return
+                        console.warn('Failed to send start-model-download message:', err)
+                        this.isModelDownloading = false
+                        this.downloadProgress = null
+                        this.downloadError = err instanceof Error ? err.message : String(err)
+                        this.requestUpdate()
+                    }
+                    return
+                }
+            } else if (this.isModelDownloading) {
+                // トグルOFF（ダウンロード中）: ユーザーキャンセル
+                this.isUserCancellingDownload = true
+                this.isModelDownloading = false
                 this.downloadProgress = null
+                this.downloadError = null
                 this.requestUpdate()
                 try {
-                    await chrome.runtime.sendMessage({ type: 'start-model-download' })
+                    await chrome.runtime.sendMessage({ type: 'cancel-model-download' })
                 } catch (err) {
-                    console.warn('Failed to send start-model-download message:', err)
-                    this.isModelDownloading = false
-                    this.downloadProgress = null
-                    this.downloadError = err instanceof Error ? err.message : String(err)
-                    this.requestUpdate()
+                    console.warn('Failed to send cancel-model-download message:', err)
                 }
-                return
+            } else {
+                // トグルOFF（キャッシュ済み or 無効状態）: キャッシュ削除
+                await this.modelCache.clear()
+                if (this.transcriptionToggleGeneration !== currentGen) return
+                this.hasCacheInconsistency = false
+                this.requestUpdate()
             }
-        } else if (this.isModelDownloading) {
-            // トグルOFF（ダウンロード中）: ユーザーキャンセル
-            this.isUserCancellingDownload = true
-            this.isModelDownloading = false
-            this.downloadProgress = null
-            this.downloadError = null
-            this.requestUpdate()
-            try {
-                await chrome.runtime.sendMessage({ type: 'cancel-model-download' })
-            } catch (err) {
-                console.warn('Failed to send cancel-model-download message:', err)
-            }
-        } else {
-            // トグルOFF（キャッシュ済み or 無効状態）: キャッシュ削除
-            await this.modelCache.clear()
-            this.requestUpdate()
-        }
 
-        const oldVal = { ...this.config }
-        this.config.transcription.enabled = enabled
-        this.requestUpdate('config', oldVal)
-        Settings.setConfiguration(this.config)
-        await Settings.syncConfiguration(this.config)
+            if (this.transcriptionToggleGeneration !== currentGen) return
+
+            const oldVal = { ...this.config }
+            this.config.transcription.enabled = enabled
+            this.requestUpdate('config', oldVal)
+            Settings.setConfiguration(this.config)
+            await Settings.syncConfiguration(this.config)
+        } finally {
+            if (this.transcriptionToggleGeneration === currentGen) {
+                this.isTogglingTranscription = false
+                this.requestUpdate()
+            }
+        }
     }
 }
 

--- a/src/element/settings.ts
+++ b/src/element/settings.ts
@@ -48,6 +48,8 @@ import { registerFlacEncoder } from '@mediabunny/flac-encoder'
 import { OPFSModelCache } from '../transcription/opfs_model_cache'
 import { ModelDownloader } from '../transcription/model_downloader'
 import { TRANSCRIPTION_LANGUAGES } from '../transcription/languages'
+import { checkWebGPUSupport } from '../transcription/webgpu'
+import type { WebGPUSupportReason } from '../transcription/webgpu'
 
 @customElement('extension-settings')
 export class Settings extends LitElement {
@@ -187,6 +189,9 @@ export class Settings extends LitElement {
                 margin-bottom: 1rem;
                 white-space: pre-line;
             }
+            .settings-hint.error {
+                color: var(--md-sys-color-error, #b3261e);
+            }
             .download-progress-area {
                 margin-top: 0.5rem;
                 margin-bottom: 0.5rem;
@@ -229,6 +234,15 @@ export class Settings extends LitElement {
 
     @property()
     private downloadError: string | null = null
+
+    @property()
+    private isWebGPUSupported: boolean = true
+
+    @property()
+    private transcriptionUnsupportedReason: WebGPUSupportReason | null = null
+
+    @property()
+    private isCheckingWebGPU: boolean = false
 
     @property()
     private timerEstimateText: string = ''
@@ -654,14 +668,19 @@ export class Settings extends LitElement {
                 <div class="settings-group">
                     <label
                         class="switch-label"
-                        title="${t('settingsTranscriptionTitle', ModelDownloader.getFormattedTotalSize())}">
+                        title="${
+                            !this.isWebGPUSupported
+                                ? this.transcriptionHintText
+                                : t('settingsTranscriptionTitle', ModelDownloader.getFormattedTotalSize())
+                        }">
                         ${t('settingsTranscription')}
                         <md-switch
                             id="transcription-switch"
                             ?selected=${live((this.config.transcription?.enabled ?? false) || this.isModelDownloading)}
+                            ?disabled=${live(!this.isWebGPUSupported || this.isCheckingWebGPU)}
                             @input=${this.updateTranscriptionEnabled}></md-switch>
                     </label>
-                    <p class="settings-hint">${this.transcriptionHintText}</p>
+                    <p class="settings-hint ${!this.isWebGPUSupported ? 'error' : ''}">${this.transcriptionHintText}</p>
 
                     ${
                         this.isModelDownloading
@@ -923,6 +942,12 @@ export class Settings extends LitElement {
     }
 
     private get transcriptionHintText(): string {
+        if (!this.isWebGPUSupported) {
+            if (this.transcriptionUnsupportedReason === 'no-shader-f16') {
+                return t('settingsTranscriptionUnsupportedShaderF16')
+            }
+            return t('settingsTranscriptionUnsupportedWebGPU')
+        }
         const modelSize = ModelDownloader.getFormattedTotalSize()
         if (this.isModelDownloading) {
             return t('settingsTranscriptionDownloadingHint')
@@ -1237,12 +1262,32 @@ export class Settings extends LitElement {
     private isUserCancellingDownload = false
 
     private async updateTranscriptionEnabled(e: Event) {
-        if (!(e.target instanceof MdSwitch)) return
-        const enabled = e.target.selected
+        const target = e.target
+        if (!(target instanceof MdSwitch)) return
+        const enabled = target.selected
 
         if (enabled) {
-            // トグルON: モデルがキャッシュ済みならそのまま有効化、未キャッシュなら即ダウンロード開始
             this.downloadError = null
+            this.isCheckingWebGPU = true
+            this.requestUpdate()
+
+            let gpuSupport
+            try {
+                gpuSupport = await checkWebGPUSupport()
+            } finally {
+                this.isCheckingWebGPU = false
+            }
+
+            if (!gpuSupport.supported) {
+                this.isWebGPUSupported = false
+                this.transcriptionUnsupportedReason = gpuSupport.reason ?? 'no-webgpu'
+                target.selected = false
+                this.config.transcription.enabled = false
+                this.requestUpdate()
+                return
+            }
+
+            // トグルON: モデルがキャッシュ済みならそのまま有効化、未キャッシュなら即ダウンロード開始
             const isCached = await this.modelCache.hasCache()
             if (!isCached) {
                 this.isModelDownloading = true

--- a/src/element/tab.ts
+++ b/src/element/tab.ts
@@ -6,42 +6,54 @@ import { MdTabs } from '@material/web/tabs/tabs'
 import { Tab } from '@material/web/tabs/internal/tab'
 import '@material/web/icon/icon'
 import type { Cropping } from './cropping'
+import type { Settings } from './settings'
 import { t } from '../i18n'
 
 interface TabDefinition {
     id: string
     panelId: string
-    hash: string
+    param: string
 }
 
 const TAB_DEFINITIONS: readonly TabDefinition[] = [
-    { id: 'tab-main', panelId: 'panel-main', hash: '' },
-    { id: 'tab-settings', panelId: 'panel-settings', hash: '#settings' },
-    { id: 'tab-cropping', panelId: 'panel-cropping', hash: '#cropping' },
-    { id: 'tab-support', panelId: 'panel-support', hash: '#support' },
+    { id: 'tab-main', panelId: 'panel-main', param: '' },
+    { id: 'tab-settings', panelId: 'panel-settings', param: 'settings' },
+    { id: 'tab-cropping', panelId: 'panel-cropping', param: 'cropping' },
+    { id: 'tab-support', panelId: 'panel-support', param: 'support' },
 ] as const
 
-function getTabByHash(hash: string): TabDefinition {
-    const cleanHash = hash.startsWith('#') ? hash : hash ? `#${hash}` : ''
-    return (
-        TAB_DEFINITIONS.find(tab => tab.hash !== '' && tab.hash.toLowerCase() === cleanHash.toLowerCase()) ??
-        TAB_DEFINITIONS[0]
-    )
+function getTabByParam(search: string): TabDefinition {
+    const params = new URLSearchParams(search)
+    const tabParam = params.get('tab')?.toLowerCase() ?? ''
+    if (tabParam === 'records' || tabParam === '') {
+        return TAB_DEFINITIONS[0]
+    }
+    return TAB_DEFINITIONS.find(tab => tab.param !== '' && tab.param.toLowerCase() === tabParam) ?? TAB_DEFINITIONS[0]
 }
 
-function updateHash(hash: string, replace?: boolean) {
-    if (replace) {
-        history.replaceState(null, '', window.location.pathname + window.location.search)
-        return
+function updateTabQuery(param: string, options?: { replace?: boolean; clearHash?: boolean }) {
+    const url = new URL(window.location.href)
+    if (param) {
+        url.searchParams.set('tab', param)
+    } else {
+        url.searchParams.delete('tab')
     }
-    if (hash) {
-        if (window.location.hash !== hash) {
-            history.pushState(null, '', hash)
-        }
-        return
+
+    if (options?.clearHash) {
+        url.hash = ''
     }
-    if (window.location.hash) {
-        history.pushState(null, '', window.location.pathname + window.location.search)
+
+    const newSearch = url.searchParams.toString() ? `?${url.searchParams.toString()}` : ''
+    const newHash = url.hash ? url.hash : ''
+    const newUrl = `${url.pathname}${newSearch}${newHash}`
+
+    const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`
+    if (newUrl === currentUrl) return
+
+    if (options?.replace) {
+        history.replaceState(null, '', newUrl)
+    } else {
+        history.pushState(null, '', newUrl)
     }
 }
 
@@ -53,22 +65,25 @@ export class OptionTab extends LitElement {
 
     public override connectedCallback() {
         super.connectedCallback()
-        window.addEventListener('hashchange', this.handleHashChange)
+        window.addEventListener('popstate', this.handlePopState)
     }
 
     public override disconnectedCallback() {
         super.disconnectedCallback()
-        window.removeEventListener('hashchange', this.handleHashChange)
+        window.removeEventListener('popstate', this.handlePopState)
     }
 
     public override firstUpdated() {
-        const currentHash = window.location.hash
-        const activeTab = getTabByHash(currentHash)
-        if (currentHash && activeTab.hash === '') {
-            updateHash('', true)
+        const currentTabParam = new URLSearchParams(window.location.search).get('tab')
+        const activeTab = getTabByParam(window.location.search)
+        if (currentTabParam && activeTab.param === '' && currentTabParam !== 'records') {
+            updateTabQuery('', { replace: true, clearHash: false })
         }
         if (activeTab.id === 'tab-cropping') {
             OptionTab.notifyCroppingTabState(true)
+        }
+        if (activeTab.id === 'tab-settings') {
+            OptionTab.notifySettingsTabState(true)
         }
     }
 
@@ -86,6 +101,14 @@ export class OptionTab extends LitElement {
         }
     }
 
+    private static async notifySettingsTabState(isActive: boolean) {
+        await customElements.whenDefined('extension-settings')
+        const settingsElement = document.querySelector<Settings>('extension-settings')
+        if (settingsElement && typeof settingsElement.setTabActive === 'function') {
+            settingsElement.setTabActive(isActive)
+        }
+    }
+
     private syncTabPanels(tabs: MdTabs, activeTab: Tab | null) {
         tabs.tabs.forEach(tab => {
             if (tab === activeTab) return
@@ -97,6 +120,9 @@ export class OptionTab extends LitElement {
             // Notify cropping tab when it becomes inactive
             if (tab.id === 'tab-cropping') {
                 OptionTab.notifyCroppingTabState(false)
+            }
+            if (tab.id === 'tab-settings') {
+                OptionTab.notifySettingsTabState(false)
             }
         })
 
@@ -110,9 +136,15 @@ export class OptionTab extends LitElement {
         if (activeTab.id === 'tab-cropping') {
             OptionTab.notifyCroppingTabState(true)
         }
+        if (activeTab.id === 'tab-settings') {
+            OptionTab.notifySettingsTabState(true)
+        }
     }
 
+    private isPopStateNavigating = false
+
     private changeTab = (e: Event) => {
+        if (this.isPopStateNavigating) return
         if (!(e.target instanceof MdTabs)) return
         const tabs = e.target
 
@@ -121,30 +153,37 @@ export class OptionTab extends LitElement {
         const activeTabId = tabs.activeTab?.id
         const tabDef = TAB_DEFINITIONS.find(item => item.id === activeTabId)
         if (tabDef) {
-            updateHash(tabDef.hash)
+            updateTabQuery(tabDef.param, { clearHash: true })
         }
     }
 
-    private handleHashChange = () => {
-        const activeTabDef = getTabByHash(window.location.hash)
-        if (window.location.hash && activeTabDef.hash === '') {
-            updateHash('', true)
-        }
-        const tabs = this.shadowRoot?.querySelector<MdTabs>('md-tabs')
-        if (!tabs) return
+    private handlePopState = () => {
+        this.isPopStateNavigating = true
+        try {
+            const currentTabParam = new URLSearchParams(window.location.search).get('tab')
+            const activeTabDef = getTabByParam(window.location.search)
+            if (currentTabParam && activeTabDef.param === '' && currentTabParam !== 'records') {
+                updateTabQuery('', { replace: true, clearHash: false })
+            }
+            const tabs = this.shadowRoot?.querySelector<MdTabs>('md-tabs')
+            if (!tabs) return
 
-        const targetTab = tabs.tabs.find(tab => tab.id === activeTabDef.id)
-        if (!targetTab) return
+            const targetTab = tabs.tabs.find(tab => tab.id === activeTabDef.id)
+            if (!targetTab) return
 
-        if (tabs.activeTab !== targetTab) {
-            tabs.activeTab = targetTab
-        } else {
+            if (tabs.activeTab !== targetTab) {
+                tabs.activeTab = targetTab
+            }
             this.syncTabPanels(tabs, targetTab)
+        } finally {
+            queueMicrotask(() => {
+                this.isPopStateNavigating = false
+            })
         }
     }
 
     public override render() {
-        const activeTab = getTabByHash(window.location.hash)
+        const activeTab = getTabByParam(window.location.search)
 
         return html`
             <md-tabs @change=${this.changeTab}>

--- a/src/transcription/model_files.ts
+++ b/src/transcription/model_files.ts
@@ -30,8 +30,8 @@ export const REQUIRED_MODEL_FILES: readonly RequiredModelFile[] = [
     {
         repo: WHISPER_MODEL_REPO,
         revision: WHISPER_MODEL_REVISION,
-        name: 'onnx/decoder_model_merged_q4.onnx',
-        size: 334147222,
+        name: 'onnx/decoder_model_merged_q4f16.onnx',
+        size: 193505017,
     },
     // Silero VAD
     { repo: VAD_MODEL_REPO, revision: VAD_MODEL_REVISION, name: 'onnx/model.onnx', size: 2243022 },

--- a/src/transcription/webgpu.ts
+++ b/src/transcription/webgpu.ts
@@ -1,0 +1,51 @@
+interface GPUAdapterFeatures {
+    has(name: string): boolean
+}
+
+interface GPUAdapterLike {
+    readonly features?: GPUAdapterFeatures
+}
+
+interface GPULike {
+    requestAdapter(options?: unknown): Promise<GPUAdapterLike | null>
+}
+
+interface NavigatorWithGPU {
+    gpu?: GPULike
+}
+
+export type WebGPUSupportReason = 'no-webgpu' | 'no-shader-f16'
+
+export interface WebGPUSupportResult {
+    supported: boolean
+    reason?: WebGPUSupportReason
+}
+
+/**
+ * Checks if the browser environment supports WebGPU and the shader-f16 feature.
+ */
+export async function checkWebGPUSupport(): Promise<WebGPUSupportResult> {
+    if (typeof navigator === 'undefined') {
+        return { supported: false, reason: 'no-webgpu' }
+    }
+
+    const nav = navigator as unknown as NavigatorWithGPU
+    if (!nav.gpu || typeof nav.gpu.requestAdapter !== 'function') {
+        return { supported: false, reason: 'no-webgpu' }
+    }
+
+    try {
+        const adapter = await nav.gpu.requestAdapter()
+        if (!adapter) {
+            return { supported: false, reason: 'no-webgpu' }
+        }
+
+        if (!adapter.features || typeof adapter.features.has !== 'function' || !adapter.features.has('shader-f16')) {
+            return { supported: false, reason: 'no-shader-f16' }
+        }
+
+        return { supported: true }
+    } catch {
+        return { supported: false, reason: 'no-webgpu' }
+    }
+}

--- a/src/transcription/worker.ts
+++ b/src/transcription/worker.ts
@@ -222,7 +222,7 @@ class WhisperPipelineManager {
 
         const dtype = {
             encoder_model: 'fp16',
-            decoder_model_merged: 'q4',
+            decoder_model_merged: 'q4f16',
         } as const
 
         try {

--- a/tests/element/player.test.ts
+++ b/tests/element/player.test.ts
@@ -22,6 +22,16 @@ vi.mock('../../src/api_client', () => ({
     },
 }))
 
+const hasCacheMock = vi.fn().mockResolvedValue(true)
+vi.mock('../../src/transcription/opfs_model_cache', () => {
+    class MockOPFSModelCache {
+        hasCache = (...args: unknown[]) => hasCacheMock(...args)
+    }
+    return {
+        OPFSModelCache: MockOPFSModelCache,
+    }
+})
+
 // Import player after mocks
 import '../../src/element/player'
 
@@ -121,5 +131,55 @@ describe('extension-player', () => {
 
         await elementUpdated(el)
         expect(shadowQuery(el, 'video track')).toBeNull()
+    })
+
+    test('shows model redownload error and open settings button when hasCache returns false', async () => {
+        hasCacheMock.mockResolvedValue(false)
+        const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+        const screen = render(html`<extension-player></extension-player>`)
+        const el = screen.container.querySelector('extension-player') as any
+        el.path = 'test-recording.webm'
+        await elementUpdated(el)
+
+        await el.startTranscription()
+        await elementUpdated(el)
+
+        const errorBanner = shadowQuery(el, '.error-banner')
+        expect(errorBanner).not.toBeNull()
+        expect(errorBanner?.textContent).toContain('Transcription model is missing or corrupted')
+
+        const openSettingsBtn = shadowQuery(el, '.open-settings-button')
+        expect(openSettingsBtn).not.toBeNull()
+
+        // Click settings button
+        openSettingsBtn?.dispatchEvent(new Event('click'))
+        expect(windowOpenSpy).toHaveBeenCalledWith(
+            expect.stringContaining('option.html?tab=settings#transcription'),
+            '_blank',
+        )
+
+        const chromeMock = getChromeMock()
+        expect(chromeMock.runtime.sendMessage).not.toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'start-transcription' }),
+        )
+    })
+
+    test('starts transcription when hasCache returns true', async () => {
+        hasCacheMock.mockResolvedValue(true)
+
+        const screen = render(html`<extension-player></extension-player>`)
+        const el = screen.container.querySelector('extension-player') as any
+        el.path = 'test-recording.webm'
+        await elementUpdated(el)
+
+        await el.startTranscription()
+        await elementUpdated(el)
+
+        const chromeMock = getChromeMock()
+        expect(chromeMock.runtime.sendMessage).toHaveBeenCalledWith({
+            type: 'start-transcription',
+            path: 'test-recording.webm',
+        })
     })
 })

--- a/tests/element/settings.test.ts
+++ b/tests/element/settings.test.ts
@@ -78,6 +78,18 @@ vi.mock('../../src/transcription/webgpu', () => ({
     checkWebGPUSupport: () => mockCheckWebGPUSupport(),
 }))
 
+const mockHasCache = vi.fn().mockResolvedValue(true)
+const mockClear = vi.fn().mockResolvedValue(undefined)
+vi.mock('../../src/transcription/opfs_model_cache', () => {
+    class MockOPFSModelCache {
+        hasCache = () => mockHasCache()
+        clear = () => mockClear()
+    }
+    return {
+        OPFSModelCache: MockOPFSModelCache,
+    }
+})
+
 describe('extension-settings', () => {
     test('renders Appearance heading with theme selector', async () => {
         const screen = render(html`<extension-settings></extension-settings>`)
@@ -285,7 +297,7 @@ describe('extension-settings', () => {
         const expSection = shadowQuery(el, '.experimental-section')!
         const hintEl = expSection.querySelector('.settings-hint')!
         expect(hintEl.textContent?.trim()).toBe(
-            'When enabled, transcription works entirely within your local environment.\nApproximately 1.5 GB of model data will be downloaded, so please be mindful of your network environment.',
+            'When enabled, transcription works entirely within your local environment.\nApproximately 1.4 GB of model data will be downloaded, so please be mindful of your network environment.',
         )
 
         // 2. Downloading state
@@ -302,7 +314,7 @@ describe('extension-settings', () => {
         el.config = config
         el.requestUpdate()
         await elementUpdated(el)
-        expect(hintEl.textContent?.trim()).toBe('Disabling will delete the cached model data (~1.5 GB).')
+        expect(hintEl.textContent?.trim()).toBe('Disabling will delete the cached model data (~1.4 GB).')
     })
 
     test('disables transcription switch and shows unsupported message when WebGPU is not supported on toggle', async () => {
@@ -311,7 +323,7 @@ describe('extension-settings', () => {
         const el = screen.container.querySelector('extension-settings')!
         await elementUpdated(el)
 
-        const transcriptionSwitch = shadowQuery(el, '#transcription-switch') as any
+        const transcriptionSwitch = shadowQuery(el, '#transcription') as any
         expect(transcriptionSwitch).not.toBeNull()
         expect(transcriptionSwitch.disabled).toBeFalsy()
 
@@ -341,7 +353,7 @@ describe('extension-settings', () => {
         const el = screen.container.querySelector('extension-settings')!
         await elementUpdated(el)
 
-        const transcriptionSwitch = shadowQuery(el, '#transcription-switch') as any
+        const transcriptionSwitch = shadowQuery(el, '#transcription') as any
         expect(transcriptionSwitch).not.toBeNull()
 
         // Toggle transcription ON
@@ -366,11 +378,12 @@ describe('extension-settings', () => {
 
     test('starts model download when WebGPU and shader-f16 are supported on toggle', async () => {
         mockCheckWebGPUSupport.mockResolvedValueOnce({ supported: true })
+        mockHasCache.mockResolvedValueOnce(false)
         const screen = render(html`<extension-settings></extension-settings>`)
         const el = screen.container.querySelector('extension-settings')!
         await elementUpdated(el)
 
-        const transcriptionSwitch = shadowQuery(el, '#transcription-switch') as any
+        const transcriptionSwitch = shadowQuery(el, '#transcription') as any
         expect(transcriptionSwitch).not.toBeNull()
 
         // Toggle transcription ON
@@ -378,12 +391,184 @@ describe('extension-settings', () => {
         transcriptionSwitch.dispatchEvent(new Event('input'))
         await elementUpdated(el)
 
-        // Switch should not be disabled
-        expect(transcriptionSwitch.disabled).toBe(false)
-
         // Should have sent start-model-download message
         await vi.waitFor(() => {
             expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'start-model-download' })
         })
+
+        // Switch should not be disabled after toggle operation completes
+        await vi.waitFor(() => {
+            expect(transcriptionSwitch.disabled).toBe(false)
+        })
+    })
+
+    test('invalidates stale ON handler when toggled OFF before cache check completes', async () => {
+        let resolveCacheCheck!: (value: boolean) => void
+        mockCheckWebGPUSupport.mockResolvedValueOnce({ supported: true })
+        mockHasCache.mockImplementationOnce(
+            () =>
+                new Promise<boolean>(resolve => {
+                    resolveCacheCheck = resolve
+                }),
+        )
+
+        const screen = render(html`<extension-settings></extension-settings>`)
+        const el = screen.container.querySelector('extension-settings')!
+        await elementUpdated(el)
+
+        const transcriptionSwitch = shadowQuery(el, '#transcription') as any
+        expect(transcriptionSwitch).not.toBeNull()
+
+        // Toggle ON (initiates WebGPU check and then hangs on hasCache())
+        transcriptionSwitch.selected = true
+        transcriptionSwitch.dispatchEvent(new Event('input'))
+        await elementUpdated(el)
+
+        // Switch is locked while operation is pending
+        expect(transcriptionSwitch.disabled).toBe(true)
+
+        // User quickly toggles OFF before cache check resolves
+        transcriptionSwitch.selected = false
+        transcriptionSwitch.dispatchEvent(new Event('input'))
+        await elementUpdated(el)
+
+        // Now resolve the stale hasCache() call with false (which would normally trigger model download)
+        resolveCacheCheck(false)
+        await elementUpdated(el)
+
+        // Stale handler must have been invalidated: start-model-download should not be called
+        expect(chrome.runtime.sendMessage).not.toHaveBeenCalledWith({ type: 'start-model-download' })
+
+        // Config should remain disabled
+        const config = Settings.getConfiguration()
+        expect(config.transcription.enabled).toBe(false)
+    })
+
+    test('detects cache inconsistency and shows redownload warning when transcription is enabled but cache is missing', async () => {
+        mockHasCache.mockResolvedValue(false)
+        const config = Settings.getConfiguration()
+        config.transcription.enabled = true
+        Settings.setConfiguration(config)
+
+        const screen = render(html`<extension-settings></extension-settings>`)
+        const el = screen.container.querySelector('extension-settings')!
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            const hintEl = shadowQuery(el, '.settings-hint')!
+            expect(hintEl.classList.contains('error')).toBe(true)
+            expect(hintEl.textContent?.trim()).toBe(
+                'Model data is missing or corrupted. Please toggle transcription off and on again to redownload the model.',
+            )
+        })
+
+        // Switch remains enabled (selected)
+        const transcriptionSwitch = shadowQuery(el, '#transcription') as any
+        expect(transcriptionSwitch.selected).toBe(true)
+    })
+
+    test('clears cache inconsistency warning when user toggles transcription off', async () => {
+        mockHasCache.mockResolvedValue(false)
+        const config = Settings.getConfiguration()
+        config.transcription.enabled = true
+        Settings.setConfiguration(config)
+
+        const screen = render(html`<extension-settings></extension-settings>`)
+        const el = screen.container.querySelector('extension-settings') as any
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            expect(el.hasCacheInconsistency).toBe(true)
+        })
+
+        // Toggle OFF
+        const transcriptionSwitch = shadowQuery(el, '#transcription') as any
+        transcriptionSwitch.selected = false
+        transcriptionSwitch.dispatchEvent(new Event('input'))
+        await elementUpdated(el)
+
+        await vi.waitFor(() => {
+            expect(el.hasCacheInconsistency).toBe(false)
+            expect(mockClear).toHaveBeenCalled()
+        })
+
+        const hintEl = shadowQuery(el, '.settings-hint')!
+        expect(hintEl.classList.contains('error')).toBe(false)
+    })
+
+    test('re-checks cache consistency on setTabActive(true)', async () => {
+        mockHasCache.mockResolvedValue(true)
+        const config = Settings.getConfiguration()
+        config.transcription.enabled = true
+        Settings.setConfiguration(config)
+
+        const screen = render(html`<extension-settings></extension-settings>`)
+        const el = screen.container.querySelector('extension-settings') as any
+        await elementUpdated(el)
+
+        expect(el.hasCacheInconsistency).toBe(false)
+
+        // Cache disappears while tab was inactive
+        mockHasCache.mockResolvedValue(false)
+
+        await el.setTabActive(true)
+        await elementUpdated(el)
+
+        expect(el.hasCacheInconsistency).toBe(true)
+    })
+
+    test('does not set hasCacheInconsistency if transcription is toggled off while checkCacheConsistency is pending', async () => {
+        let resolveHasCache!: (val: boolean) => void
+        mockHasCache.mockImplementation(
+            () =>
+                new Promise(resolve => {
+                    resolveHasCache = resolve
+                }),
+        )
+
+        const config = Settings.getConfiguration()
+        config.transcription.enabled = true
+        Settings.setConfiguration(config)
+
+        const screen = render(html`<extension-settings></extension-settings>`)
+        const el = screen.container.querySelector('extension-settings') as any
+        await elementUpdated(el)
+
+        // Start pending checkCacheConsistency
+        const checkPromise = el.checkCacheConsistency()
+
+        // User toggles transcription OFF while check is pending
+        const transcriptionSwitch = shadowQuery(el, '#transcription') as any
+        transcriptionSwitch.selected = false
+        transcriptionSwitch.dispatchEvent(new Event('input'))
+        await elementUpdated(el)
+
+        // Resolve hasCache with false (model missing) after OFF toggle
+        resolveHasCache(false)
+        await checkPromise
+        await elementUpdated(el)
+
+        expect(el.hasCacheInconsistency).toBe(false)
+        const hintEl = shadowQuery(el, '.settings-hint')!
+        expect(hintEl.classList.contains('error')).toBe(false)
+    })
+
+    test('scrolls to transcription switch when hash is #transcription', async () => {
+        history.replaceState(null, '', '?tab=settings#transcription')
+
+        const screen = render(html`<extension-settings></extension-settings>`)
+        const el = screen.container.querySelector('extension-settings')!
+        await elementUpdated(el)
+
+        const switchEl = shadowQuery(el, '#transcription')!
+        const scrollSpy = vi.spyOn(switchEl, 'scrollIntoView').mockImplementation(() => {})
+
+        await (el as any).checkAnchorNavigation()
+
+        await vi.waitFor(() => {
+            expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' })
+        })
+
+        history.replaceState(null, '', window.location.pathname)
     })
 })

--- a/tests/element/settings.test.ts
+++ b/tests/element/settings.test.ts
@@ -73,6 +73,11 @@ vi.mock('../../src/theme', () => ({
     applyTheme: vi.fn(),
 }))
 
+const mockCheckWebGPUSupport = vi.fn().mockResolvedValue({ supported: true })
+vi.mock('../../src/transcription/webgpu', () => ({
+    checkWebGPUSupport: () => mockCheckWebGPUSupport(),
+}))
+
 describe('extension-settings', () => {
     test('renders Appearance heading with theme selector', async () => {
         const screen = render(html`<extension-settings></extension-settings>`)
@@ -298,5 +303,87 @@ describe('extension-settings', () => {
         el.requestUpdate()
         await elementUpdated(el)
         expect(hintEl.textContent?.trim()).toBe('Disabling will delete the cached model data (~1.5 GB).')
+    })
+
+    test('disables transcription switch and shows unsupported message when WebGPU is not supported on toggle', async () => {
+        mockCheckWebGPUSupport.mockResolvedValueOnce({ supported: false, reason: 'no-webgpu' })
+        const screen = render(html`<extension-settings></extension-settings>`)
+        const el = screen.container.querySelector('extension-settings')!
+        await elementUpdated(el)
+
+        const transcriptionSwitch = shadowQuery(el, '#transcription-switch') as any
+        expect(transcriptionSwitch).not.toBeNull()
+        expect(transcriptionSwitch.disabled).toBeFalsy()
+
+        // Toggle transcription ON
+        transcriptionSwitch.selected = true
+        transcriptionSwitch.dispatchEvent(new Event('input'))
+
+        await vi.waitFor(() => {
+            expect(transcriptionSwitch.disabled).toBe(true)
+        })
+        expect(transcriptionSwitch.selected).toBe(false)
+
+        // Hint should display WebGPU unsupported message with error style
+        const hintEl = shadowQuery(el, '.settings-hint')!
+        expect(hintEl.classList.contains('error')).toBe(true)
+        expect(hintEl.textContent?.trim()).toBe(
+            'Transcription is not available because your browser does not support WebGPU.',
+        )
+
+        // Should not have sent start-model-download message
+        expect(chrome.runtime.sendMessage).not.toHaveBeenCalledWith({ type: 'start-model-download' })
+    })
+
+    test('disables transcription switch and shows unsupported message when shader-f16 is not supported on toggle', async () => {
+        mockCheckWebGPUSupport.mockResolvedValueOnce({ supported: false, reason: 'no-shader-f16' })
+        const screen = render(html`<extension-settings></extension-settings>`)
+        const el = screen.container.querySelector('extension-settings')!
+        await elementUpdated(el)
+
+        const transcriptionSwitch = shadowQuery(el, '#transcription-switch') as any
+        expect(transcriptionSwitch).not.toBeNull()
+
+        // Toggle transcription ON
+        transcriptionSwitch.selected = true
+        transcriptionSwitch.dispatchEvent(new Event('input'))
+
+        await vi.waitFor(() => {
+            expect(transcriptionSwitch.disabled).toBe(true)
+        })
+        expect(transcriptionSwitch.selected).toBe(false)
+
+        // Hint should display shader-f16 unsupported message with error style
+        const hintEl = shadowQuery(el, '.settings-hint')!
+        expect(hintEl.classList.contains('error')).toBe(true)
+        expect(hintEl.textContent?.trim()).toBe(
+            'Transcription is not available because your browser or GPU does not support WebGPU shader-f16.',
+        )
+
+        // Should not have sent start-model-download message
+        expect(chrome.runtime.sendMessage).not.toHaveBeenCalledWith({ type: 'start-model-download' })
+    })
+
+    test('starts model download when WebGPU and shader-f16 are supported on toggle', async () => {
+        mockCheckWebGPUSupport.mockResolvedValueOnce({ supported: true })
+        const screen = render(html`<extension-settings></extension-settings>`)
+        const el = screen.container.querySelector('extension-settings')!
+        await elementUpdated(el)
+
+        const transcriptionSwitch = shadowQuery(el, '#transcription-switch') as any
+        expect(transcriptionSwitch).not.toBeNull()
+
+        // Toggle transcription ON
+        transcriptionSwitch.selected = true
+        transcriptionSwitch.dispatchEvent(new Event('input'))
+        await elementUpdated(el)
+
+        // Switch should not be disabled
+        expect(transcriptionSwitch.disabled).toBe(false)
+
+        // Should have sent start-model-download message
+        await vi.waitFor(() => {
+            expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ type: 'start-model-download' })
+        })
     })
 })

--- a/tests/element/tab.test.ts
+++ b/tests/element/tab.test.ts
@@ -10,17 +10,17 @@ function renderTab() {
     return screen.container.querySelector('option-tab') as OptionTab
 }
 
-function waitForHashChange(timeoutMs = 1000): Promise<void> {
+function waitForPopState(timeoutMs = 1000): Promise<void> {
     return new Promise<void>((resolve, reject) => {
         const timer = setTimeout(() => {
-            window.removeEventListener('hashchange', onHashChange)
-            reject(new Error(`Timeout waiting for hashchange event (${timeoutMs}ms)`))
+            window.removeEventListener('popstate', onPopState)
+            reject(new Error(`Timeout waiting for popstate event (${timeoutMs}ms)`))
         }, timeoutMs)
-        const onHashChange = () => {
+        const onPopState = () => {
             clearTimeout(timer)
             resolve()
         }
-        window.addEventListener('hashchange', onHashChange, { once: true })
+        window.addEventListener('popstate', onPopState, { once: true })
     })
 }
 
@@ -94,13 +94,13 @@ describe('option-tab', () => {
         expect(slotNames).toContain('panel-support')
     })
 
-    describe('hash handling', () => {
+    describe('tab query param handling', () => {
         afterEach(() => {
-            history.replaceState(null, '', window.location.pathname + window.location.search)
+            history.replaceState(null, '', window.location.pathname)
         })
 
-        test('activates Settings tab when hash is #settings', async () => {
-            history.replaceState(null, '', '#settings')
+        test('activates Settings tab when tab param is settings', async () => {
+            history.replaceState(null, '', '?tab=settings')
             const el = renderTab()
             await elementUpdated(el)
 
@@ -113,8 +113,8 @@ describe('option-tab', () => {
             expect(mainPanel?.hasAttribute('hidden')).toBe(true)
         })
 
-        test('activates Cropping tab when hash is #cropping', async () => {
-            history.replaceState(null, '', '#cropping')
+        test('activates Cropping tab when tab param is cropping', async () => {
+            history.replaceState(null, '', '?tab=cropping')
             const el = renderTab()
             await elementUpdated(el)
 
@@ -127,8 +127,8 @@ describe('option-tab', () => {
             expect(mainPanel?.hasAttribute('hidden')).toBe(true)
         })
 
-        test('activates Support tab when hash is #support', async () => {
-            history.replaceState(null, '', '#support')
+        test('activates Support tab when tab param is support', async () => {
+            history.replaceState(null, '', '?tab=support')
             const el = renderTab()
             await elementUpdated(el)
 
@@ -141,8 +141,8 @@ describe('option-tab', () => {
             expect(mainPanel?.hasAttribute('hidden')).toBe(true)
         })
 
-        test('activates corresponding tab with case-insensitive hash e.g. #SETTINGS', async () => {
-            history.replaceState(null, '', '#SETTINGS')
+        test('activates corresponding tab with case-insensitive tab param e.g. ?tab=SETTINGS', async () => {
+            history.replaceState(null, '', '?tab=SETTINGS')
             const el = renderTab()
             await elementUpdated(el)
 
@@ -152,8 +152,8 @@ describe('option-tab', () => {
             expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
         })
 
-        test('defaults to first tab and clears hash when hash is only #', async () => {
-            history.replaceState(null, '', window.location.pathname + window.location.search + '#')
+        test('activates Records tab when tab param is records', async () => {
+            history.replaceState(null, '', '?tab=records')
             const el = renderTab()
             await elementUpdated(el)
 
@@ -161,18 +161,16 @@ describe('option-tab', () => {
             const mainPanel = shadowQuery(el, '#panel-main')
             expect(mainTab?.hasAttribute('active')).toBe(true)
             expect(mainPanel?.hasAttribute('hidden')).toBe(false)
-            expect(window.location.hash).toBe('')
         })
 
-        test('displays first tab and has no back history when opened with undefined hash in a new tab', async () => {
+        test('displays first tab and has no back history when opened with undefined tab in a new tab', async () => {
             // In a fresh tab session, there is no back history yet
             if ((window as any).navigation) {
                 expect((window as any).navigation.canGoBack).toBe(false)
             }
 
-            // Set undefined hash on current page (simulating opening option page with undefined hash in a fresh tab)
-            history.replaceState(null, '', '#unknown')
-            expect(window.location.hash).toBe('#unknown')
+            history.replaceState(null, '', '?tab=unknown')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('unknown')
 
             const pushStateSpy = vi.spyOn(history, 'pushState')
             const replaceStateSpy = vi.spyOn(history, 'replaceState')
@@ -188,12 +186,12 @@ describe('option-tab', () => {
             expect(mainTab?.hasAttribute('active')).toBe(true)
             expect(mainPanel?.hasAttribute('hidden')).toBe(false)
 
-            // The undefined hash should be cleared
-            expect(window.location.hash).toBe('')
+            // The undefined tab query param should be cleared
+            expect(new URLSearchParams(window.location.search).get('tab')).toBeNull()
 
             // Verify no history entry was added and replaceState was used
             expect(pushStateSpy).not.toHaveBeenCalled()
-            expect(replaceStateSpy).toHaveBeenCalledWith(null, '', window.location.pathname + window.location.search)
+            expect(replaceStateSpy).toHaveBeenCalledWith(null, '', window.location.pathname)
             expect(history.length).toBe(lengthBefore)
 
             // There should be no back history in this tab
@@ -205,7 +203,7 @@ describe('option-tab', () => {
             replaceStateSpy.mockRestore()
         })
 
-        test('updates hash when switching tabs and removes hash for first tab', async () => {
+        test('updates tab query param when switching tabs and removes tab param for first tab', async () => {
             const el = renderTab()
             await elementUpdated(el)
 
@@ -217,29 +215,79 @@ describe('option-tab', () => {
 
             // Switch to Settings
             tabs.activeTab = settingsTab
-            expect(window.location.hash).toBe('#settings')
+            tabs.dispatchEvent(new Event('change'))
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('settings')
 
             // Switch to Cropping
             tabs.activeTab = croppingTab
-            expect(window.location.hash).toBe('#cropping')
+            tabs.dispatchEvent(new Event('change'))
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('cropping')
 
             // Switch to Support
             tabs.activeTab = supportTab
-            expect(window.location.hash).toBe('#support')
+            tabs.dispatchEvent(new Event('change'))
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('support')
 
             // Switch back to Records (first tab)
             tabs.activeTab = mainTab
-            expect(window.location.hash).toBe('')
+            tabs.dispatchEvent(new Event('change'))
+            expect(new URLSearchParams(window.location.search).get('tab')).toBeNull()
+            expect(window.location.search).toBe('')
         })
 
-        test('switches tab on hashchange event', async () => {
+        test('clears hash when switching tabs, but retains hash when navigating back in history', async () => {
+            history.replaceState(null, '', '?tab=settings#transcription')
             const el = renderTab()
             await elementUpdated(el)
 
-            // Change hash to #settings
-            const hashChangeToSettings = waitForHashChange()
-            window.location.hash = '#settings'
-            await hashChangeToSettings
+            expect(window.location.hash).toBe('#transcription')
+            expect(window.location.href).toContain('#transcription')
+
+            const tabs = shadowQuery(el, 'md-tabs') as any
+            const croppingTab = shadowQuery(el, '#tab-cropping') as HTMLElement
+
+            // Switch to Cropping: hash should be removed
+            tabs.activeTab = croppingTab
+            tabs.dispatchEvent(new Event('change'))
+            await elementUpdated(el)
+
+            expect(window.location.hash).toBe('')
+            expect(window.location.href).not.toContain('#')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('cropping')
+
+            // Navigate back in history: should return to settings tab with #transcription retained
+            let popState = waitForPopState()
+            history.back()
+            await popState
+            await elementUpdated(el)
+
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('settings')
+            expect(window.location.hash).toBe('#transcription')
+            expect(window.location.href).toContain('#transcription')
+
+            const settingsTab = shadowQuery(el, '#tab-settings')
+            const settingsPanel = shadowQuery(el, '#panel-settings')
+            expect(settingsTab?.hasAttribute('active')).toBe(true)
+            expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
+
+            // Navigate forward in history: should return to cropping tab without hash
+            popState = waitForPopState()
+            history.forward()
+            await popState
+            await elementUpdated(el)
+
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('cropping')
+            expect(window.location.hash).toBe('')
+            expect(window.location.href).not.toContain('#')
+        })
+
+        test('switches tab on popstate event', async () => {
+            const el = renderTab()
+            await elementUpdated(el)
+
+            // Change url to ?tab=settings
+            history.pushState(null, '', '?tab=settings')
+            window.dispatchEvent(new PopStateEvent('popstate'))
             await elementUpdated(el)
 
             const settingsTab = shadowQuery(el, '#tab-settings')
@@ -247,9 +295,9 @@ describe('option-tab', () => {
             expect(settingsTab?.hasAttribute('active')).toBe(true)
             expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
 
-            // Dispatch hashchange back to empty (first tab)
-            history.replaceState(null, '', window.location.pathname + window.location.search)
-            window.dispatchEvent(new HashChangeEvent('hashchange'))
+            // Dispatch popstate back to empty (first tab)
+            history.pushState(null, '', window.location.pathname)
+            window.dispatchEvent(new PopStateEvent('popstate'))
             await elementUpdated(el)
 
             const mainTab = shadowQuery(el, '#tab-main')
@@ -269,65 +317,68 @@ describe('option-tab', () => {
 
             // Switch tabs: records -> settings -> cropping -> support
             tabs.activeTab = settingsTab
-            expect(window.location.hash).toBe('#settings')
+            tabs.dispatchEvent(new Event('change'))
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('settings')
 
             tabs.activeTab = croppingTab
-            expect(window.location.hash).toBe('#cropping')
+            tabs.dispatchEvent(new Event('change'))
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('cropping')
 
             tabs.activeTab = supportTab
-            expect(window.location.hash).toBe('#support')
+            tabs.dispatchEvent(new Event('change'))
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('support')
 
-            // History back -> #cropping
-            let hashChange = waitForHashChange()
+            // History back -> ?tab=cropping
+            let popState = waitForPopState()
             history.back()
-            await hashChange
+            await popState
             await elementUpdated(el)
 
-            expect(window.location.hash).toBe('#cropping')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('cropping')
             const croppingPanel = shadowQuery(el, '#panel-cropping')
             expect(croppingTab.hasAttribute('active')).toBe(true)
             expect(croppingPanel?.hasAttribute('hidden')).toBe(false)
 
-            // History back -> #settings
-            hashChange = waitForHashChange()
+            // History back -> ?tab=settings
+            popState = waitForPopState()
             history.back()
-            await hashChange
+            await popState
             await elementUpdated(el)
 
-            expect(window.location.hash).toBe('#settings')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('settings')
             const settingsPanel = shadowQuery(el, '#panel-settings')
             expect(settingsTab.hasAttribute('active')).toBe(true)
             expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
 
             // History back -> empty (records)
-            hashChange = waitForHashChange()
+            popState = waitForPopState()
             history.back()
-            await hashChange
+            await popState
             await elementUpdated(el)
 
-            expect(window.location.hash).toBe('')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBeNull()
             const mainTab = shadowQuery(el, '#tab-main')
             const mainPanel = shadowQuery(el, '#panel-main')
             expect(mainTab?.hasAttribute('active')).toBe(true)
             expect(mainPanel?.hasAttribute('hidden')).toBe(false)
 
-            // History forward -> #settings
-            hashChange = waitForHashChange()
+            // History forward -> ?tab=settings
+            popState = waitForPopState()
             history.forward()
-            await hashChange
+            await popState
             await elementUpdated(el)
 
-            expect(window.location.hash).toBe('#settings')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('settings')
             expect(settingsTab.hasAttribute('active')).toBe(true)
             expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
 
-            // History forward -> #cropping
-            hashChange = waitForHashChange()
+            // History forward -> ?tab=cropping
+            popState = waitForPopState()
             history.forward()
-            await hashChange
+            await popState
             await elementUpdated(el)
 
-            expect(window.location.hash).toBe('#cropping')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('cropping')
             expect(croppingTab.hasAttribute('active')).toBe(true)
             expect(croppingPanel?.hasAttribute('hidden')).toBe(false)
         })
@@ -341,69 +392,71 @@ describe('option-tab', () => {
             const mainTab = shadowQuery(el, '#tab-main') as HTMLElement
 
             tabs.activeTab = settingsTab
-            expect(window.location.hash).toBe('#settings')
+            tabs.dispatchEvent(new Event('change'))
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('settings')
 
-            // Switch to 1st tab (removes hash via pushState)
+            // Switch to 1st tab (removes tab param via pushState)
             tabs.activeTab = mainTab
-            expect(window.location.hash).toBe('')
+            tabs.dispatchEvent(new Event('change'))
+            expect(new URLSearchParams(window.location.search).get('tab')).toBeNull()
             const mainPanel = shadowQuery(el, '#panel-main')
             expect(mainTab.hasAttribute('active')).toBe(true)
             expect(mainPanel?.hasAttribute('hidden')).toBe(false)
 
-            // History back -> #settings
-            const backHashChange = waitForHashChange()
+            // History back -> ?tab=settings
+            const backPopState = waitForPopState()
             history.back()
-            await backHashChange
+            await backPopState
             await elementUpdated(el)
 
-            expect(window.location.hash).toBe('#settings')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('settings')
             const settingsPanel = shadowQuery(el, '#panel-settings')
             expect(settingsTab.hasAttribute('active')).toBe(true)
             expect(settingsPanel?.hasAttribute('hidden')).toBe(false)
 
             // History forward -> empty (records)
-            const forwardHashChange = waitForHashChange()
+            const forwardPopState = waitForPopState()
             history.forward()
-            await forwardHashChange
+            await forwardPopState
             await elementUpdated(el)
 
-            expect(window.location.hash).toBe('')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBeNull()
             expect(mainTab.hasAttribute('active')).toBe(true)
             expect(mainPanel?.hasAttribute('hidden')).toBe(false)
         })
 
-        test('displays first tab and does not leave undefined hash in history when changing hash on already opened page', async () => {
+        test('displays first tab and does not leave undefined tab in history when changing query on already opened page', async () => {
             const el = renderTab()
             await elementUpdated(el)
 
             const tabs = shadowQuery(el, 'md-tabs') as any
             const settingsTab = shadowQuery(el, '#tab-settings') as HTMLElement
 
-            // Set up an established history entry: switch to #settings
+            // Set up an established history entry: switch to settings
             tabs.activeTab = settingsTab
-            expect(window.location.hash).toBe('#settings')
+            tabs.dispatchEvent(new Event('change'))
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('settings')
 
-            // User/browser changes hash to an undefined hash on the opened page
-            const hashChange = waitForHashChange()
-            window.location.hash = '#undefined-tab'
-            await hashChange
+            // User/browser changes query to an undefined tab on the opened page
+            history.pushState(null, '', '?tab=undefined-tab')
+            window.dispatchEvent(new PopStateEvent('popstate'))
             await elementUpdated(el)
 
-            // 1st tab should be displayed, and the undefined hash should be replaced (cleared)
+            // 1st tab should be displayed, and the undefined tab should be replaced (cleared)
             const mainTab = shadowQuery(el, '#tab-main')
             const mainPanel = shadowQuery(el, '#panel-main')
             expect(mainTab?.hasAttribute('active')).toBe(true)
             expect(mainPanel?.hasAttribute('hidden')).toBe(false)
-            expect(window.location.hash).toBe('')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBeNull()
 
-            // Undefined hash must not remain in history:
-            // Going back should directly return to #settings, NOT #undefined-tab
-            const backHashChange = waitForHashChange()
+            // Undefined tab must not remain in history:
+            // Going back should directly return to ?tab=settings, NOT ?tab=undefined-tab
+            const backPopState = waitForPopState()
             history.back()
-            await backHashChange
+            await backPopState
             await elementUpdated(el)
 
-            expect(window.location.hash).toBe('#settings')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('settings')
             expect(settingsTab.hasAttribute('active')).toBe(true)
         })
 
@@ -415,7 +468,8 @@ describe('option-tab', () => {
             const settingsTab = shadowQuery(el, '#tab-settings') as HTMLElement
 
             tabs.activeTab = settingsTab
-            expect(window.location.hash).toBe('#settings')
+            tabs.dispatchEvent(new Event('change'))
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('settings')
 
             const lengthBefore = history.length
 
@@ -423,8 +477,38 @@ describe('option-tab', () => {
             tabs.dispatchEvent(new Event('change'))
             await elementUpdated(el)
 
-            expect(window.location.hash).toBe('#settings')
+            expect(new URLSearchParams(window.location.search).get('tab')).toBe('settings')
             expect(history.length).toBe(lengthBefore)
+        })
+
+        test('notifies settings tab when switching to settings tab', async () => {
+            const setTabActiveSpy = vi.fn()
+            const mockSettings = document.createElement('div') as any
+            mockSettings.setTabActive = setTabActiveSpy
+            document.body.appendChild(mockSettings)
+
+            vi.spyOn(customElements, 'whenDefined').mockResolvedValue(undefined as any)
+            vi.spyOn(document, 'querySelector').mockImplementation((selector: string) => {
+                if (selector === 'extension-settings') return mockSettings
+                return null
+            })
+
+            const el = renderTab()
+            await elementUpdated(el)
+
+            const tabs = shadowQuery(el, 'md-tabs') as any
+            const settingsTab = shadowQuery(el, '#tab-settings') as HTMLElement
+
+            tabs.activeTab = settingsTab
+            tabs.dispatchEvent(new Event('change'))
+            await elementUpdated(el)
+
+            await vi.waitFor(() => {
+                expect(setTabActiveSpy).toHaveBeenCalledWith(true)
+            })
+
+            mockSettings.remove()
+            vi.restoreAllMocks()
         })
     })
 })

--- a/tests/model_downloader.test.ts
+++ b/tests/model_downloader.test.ts
@@ -48,12 +48,12 @@ describe('ModelDownloader', () => {
     it('getTotalSize returns sum of all required model file sizes', () => {
         const expectedTotal = REQUIRED_MODEL_FILES.reduce((sum, f) => sum + f.size, 0)
         expect(ModelDownloader.getTotalSize()).toBe(expectedTotal)
-        expect(ModelDownloader.getTotalSize()).toBeGreaterThan(1.5 * 1024 * 1024 * 1024)
-        expect(ModelDownloader.getTotalSize()).toBeLessThan(1.6 * 1024 * 1024 * 1024)
+        expect(ModelDownloader.getTotalSize()).toBeGreaterThan(1.3 * 1024 * 1024 * 1024)
+        expect(ModelDownloader.getTotalSize()).toBeLessThan(1.5 * 1024 * 1024 * 1024)
     })
 
     it('getFormattedTotalSize formats total size properly', () => {
-        expect(ModelDownloader.getFormattedTotalSize(1)).toBe('1.5 GB')
-        expect(ModelDownloader.getFormattedTotalSize(2)).toBe('1.50 GB')
+        expect(ModelDownloader.getFormattedTotalSize(1)).toBe('1.4 GB')
+        expect(ModelDownloader.getFormattedTotalSize(2)).toBe('1.37 GB')
     })
 })

--- a/tests/transcription_webgpu.test.ts
+++ b/tests/transcription_webgpu.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect, vi, afterEach } from 'vitest'
+import { checkWebGPUSupport } from '../src/transcription/webgpu'
+
+describe('checkWebGPUSupport', () => {
+    const originalNavigator = globalThis.navigator
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+        // Restore navigator
+        Object.defineProperty(globalThis, 'navigator', {
+            value: originalNavigator,
+            writable: true,
+            configurable: true,
+        })
+    })
+
+    test('returns no-webgpu if navigator has no gpu property', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {},
+            writable: true,
+            configurable: true,
+        })
+
+        const result = await checkWebGPUSupport()
+        expect(result).toEqual({ supported: false, reason: 'no-webgpu' })
+    })
+
+    test('returns no-webgpu if requestAdapter is not a function', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: { gpu: {} },
+            writable: true,
+            configurable: true,
+        })
+
+        const result = await checkWebGPUSupport()
+        expect(result).toEqual({ supported: false, reason: 'no-webgpu' })
+    })
+
+    test('returns no-webgpu if requestAdapter returns null', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                gpu: {
+                    requestAdapter: vi.fn().mockResolvedValue(null),
+                },
+            },
+            writable: true,
+            configurable: true,
+        })
+
+        const result = await checkWebGPUSupport()
+        expect(result).toEqual({ supported: false, reason: 'no-webgpu' })
+    })
+
+    test('returns no-webgpu if requestAdapter throws an error', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                gpu: {
+                    requestAdapter: vi.fn().mockRejectedValue(new Error('GPU context lost')),
+                },
+            },
+            writable: true,
+            configurable: true,
+        })
+
+        const result = await checkWebGPUSupport()
+        expect(result).toEqual({ supported: false, reason: 'no-webgpu' })
+    })
+
+    test('returns no-shader-f16 if features does not have shader-f16', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                gpu: {
+                    requestAdapter: vi.fn().mockResolvedValue({
+                        features: {
+                            has: vi.fn((feature: string) => feature !== 'shader-f16'),
+                        },
+                    }),
+                },
+            },
+            writable: true,
+            configurable: true,
+        })
+
+        const result = await checkWebGPUSupport()
+        expect(result).toEqual({ supported: false, reason: 'no-shader-f16' })
+    })
+
+    test('returns no-shader-f16 if features property is missing', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                gpu: {
+                    requestAdapter: vi.fn().mockResolvedValue({}),
+                },
+            },
+            writable: true,
+            configurable: true,
+        })
+
+        const result = await checkWebGPUSupport()
+        expect(result).toEqual({ supported: false, reason: 'no-shader-f16' })
+    })
+
+    test('returns supported: true if WebGPU and shader-f16 are supported', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                gpu: {
+                    requestAdapter: vi.fn().mockResolvedValue({
+                        features: {
+                            has: vi.fn((feature: string) => feature === 'shader-f16'),
+                        },
+                    }),
+                },
+            },
+            writable: true,
+            configurable: true,
+        })
+
+        const result = await checkWebGPUSupport()
+        expect(result).toEqual({ supported: true })
+    })
+})


### PR DESCRIPTION
This pull request improves the reliability and user experience of the transcription feature by adding robust error handling for missing or corrupted model files, and by enhancing browser and GPU compatibility checks. It also introduces better user guidance and messaging, and refactors tab navigation to use URL query parameters instead of hashes for more consistent behavior.

**Transcription feature robustness and user guidance:**
- Added checks in the `Player` and `Settings` components to detect missing or corrupted transcription model files. If the model is not present or is corrupted, users are notified with a clear error message and prompted to redownload the model, with a button that opens the Settings page for redownload. (`src/element/player.ts`, `src/element/settings.ts`) [[1]](diffhunk://#diff-3eaf2f5e9b887723700b9051f0a16bff0911de4adce96fca56e6ace93705120aR246-R252) [[2]](diffhunk://#diff-3eaf2f5e9b887723700b9051f0a16bff0911de4adce96fca56e6ace93705120aL385-R413) [[3]](diffhunk://#diff-3eaf2f5e9b887723700b9051f0a16bff0911de4adce96fca56e6ace93705120aR566-R577) [[4]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R238-R249) [[5]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R273-R274) [[6]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R952-R960) [[7]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R1227) [[8]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R1272-R1348) [[9]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R1380)

- Improved user-facing messages and error banners for various states, including missing/corrupted models, unsupported browsers, and unsupported GPU features. Added new localized strings for these cases in both English and Japanese. (`extension/_locales/en/messages.json`, `extension/_locales/ja/messages.json`) [[1]](diffhunk://#diff-6384fed49d960793ab61b9f71ac7fb91928ff924951e5f6431f883e854a643a7R902-R921) [[2]](diffhunk://#diff-5982590837dd44122bf0f35d85581d63a73a0f9f2c10cb334a76d0a7d7bb3d25R692-R706)

**Browser and GPU compatibility checks:**
- Implemented checks for WebGPU and shader-f16 support before enabling transcription. If unsupported, disables the transcription toggle and displays an appropriate error message. (`src/element/settings.ts`) [[1]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R238-R249) [[2]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R952-R960) [[3]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R1272-R1348)

**UI/UX enhancements:**
- Updated the transcription toggle and hint in Settings to reflect error or warning states with color and messaging, and disables the toggle when compatibility requirements are not met. (`src/element/settings.ts`) [[1]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R192-R194) [[2]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397L657-R690)

**Tab navigation refactor:**
- Refactored tab navigation to use URL query parameters (e.g., `?tab=settings`) instead of hashes, improving reliability and making it easier to link directly to specific tabs. Updated the logic for tab activation, browser history, and synchronization with the Settings and Cropping tabs. (`src/element/tab.ts`) [[1]](diffhunk://#diff-f5515d18c767c51fa32d2531828bf818f0efcaa55bf6cad0b23d0af1063cd954R9-R56) [[2]](diffhunk://#diff-f5515d18c767c51fa32d2531828bf818f0efcaa55bf6cad0b23d0af1063cd954L56-R87) [[3]](diffhunk://#diff-f5515d18c767c51fa32d2531828bf818f0efcaa55bf6cad0b23d0af1063cd954R104-R111) [[4]](diffhunk://#diff-f5515d18c767c51fa32d2531828bf818f0efcaa55bf6cad0b23d0af1063cd954R124-R126)

**Internal consistency and cleanup:**
- Ensured that cache inconsistency flags are reset appropriately when models are downloaded or cleared, and that UI updates reflect the current state. (`src/element/settings.ts`) [[1]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R1227) [[2]](diffhunk://#diff-6a3afbd3d38e010e061336933baa582a9e6ac9d025795eba8c19cf7d14f8f397R1380)